### PR TITLE
Fix typo 'retrun'->'return'

### DIFF
--- a/get_osc.py
+++ b/get_osc.py
@@ -26,7 +26,7 @@ def get_obj(url):
    try:
       u = urllib.urlopen(url)
    except:
-      retrun None,"Invalid URL"
+      return None,"Invalid URL"
    try:
       d = json.load(u)
    except:


### PR DESCRIPTION
Simple code typo fix for when URL call to OSC fails.