### PR TITLE
Clarify error for unsupported passband

### DIFF
--- a/sn.py
+++ b/sn.py
@@ -1408,7 +1408,7 @@ class sn(object):
       for filter in bands:
          if self.restbands[filter] not in self.model.rbs:
             raise AttributeError, \
-                  "Error:  filter %s is not supported by this model" % filter+\
+                  "Error:  filter %s is not supported by this model" % self.restbands[filter] + \
                   ", set self.restbands accordingly"
 
       if reset_kcorrs:


### PR DESCRIPTION
When a requested filter is not in the template set of supported filters, the previous error confused me by referring to the original filter name, not the remapping in restbands, which is what was checked and what matters.

This change will respond with the remapped name.