### PR TITLE
Bug fix in dump_lc()

### DIFF
--- a/snpy/sn.py
+++ b/snpy/sn.py
@@ -1441,7 +1441,7 @@ class sn(object):
             print("# column 2:  model magnitude", file=f)
             print("# column 3:  model magnitude error", file=f)
             for i in range(len(ts)):
-               print("%.1f, %.3f %.3f" % (ts[i]+self.Tmax-toff, ms[i],
+               print("%.1f %.3f %.3f" % (ts[i]+self.Tmax-toff, ms[i],
                   e_ms[i]), file=f)
             f.close()
          if self.data[filt].interp is not None:


### PR DESCRIPTION
when exporting the models from a fit, dump_lc() would add a comma after the epoch/phase column but not the others. Removed the comma from the code so that output files are loadable without manually removing the comma. 